### PR TITLE
:bug: Fixed undocumented reference of environment variable `LOCAL_MAVEN`.

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -39,9 +39,7 @@ repositories {
         }
     }
     if (!System.getenv("CI")) {
-        maven {
-            url "file://" + System.getenv("LOCAL_MAVEN")
-        }
+        mavenLocal()
     }
     maven {
         name = 'BlameJared'


### PR DESCRIPTION
`LOCAL_MAVEN` was used in `buildSrc/src/main/groovy/multiloader-common.gradle` when environment variable `CI` wasn't set, but it was not mentioned in README.md.  
I replaced it with mavenLocal(), which was built-in in Gradle.  
Also, if we want to specify the location of mavenLocal, we can use the system property named `maven.repo.local`.  

Reference: https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts.dsl/-repository-handler/maven-local.html