### PR TITLE
Add `forge:salts` compatibility

### DIFF
--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonItemTagsProvider.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonItemTagsProvider.java
@@ -1034,5 +1034,9 @@ public class CommonItemTagsProvider
         blockDisplay.add(Items.MELON);
         blockDisplay.add(Items.SLIME_BLOCK);
         blockDisplay.add(Items.HONEYCOMB_BLOCK);
+
+        // Compat to mods using forge:salts
+        TagBuilder<Item> food = builder.apply(net.minecraft.tags.ItemTags.create(new ResourceLocation("forge", "salts")));
+        food.add(ModItems.SEA_SALT.get());
     }
 }

--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonRecipeProvider.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonRecipeProvider.java
@@ -44,6 +44,8 @@ public class CommonRecipeProvider
     private final Function<ItemLike, CriterionTriggerInstance> hasItem;
     private final Function<TagKey<Item>, CriterionTriggerInstance> hasTag;
 
+    private static final TagKey<Item> FORGE_SALTS = net.minecraft.tags.ItemTags.create(new ResourceLocation("forge", "salts"));
+
     public CommonRecipeProvider(Consumer<FinishedRecipe> consumer, ConditionalModConsumer modLoadedConsumer, Function<ItemLike, CriterionTriggerInstance> hasItem, Function<TagKey<Item>, CriterionTriggerInstance> hasTag)
     {
         this.consumer = consumer;
@@ -138,10 +140,10 @@ public class CommonRecipeProvider
             .save(this.consumer);
 
         ShapelessRecipeBuilder.shapeless(RecipeCategory.FOOD, ModItems.CHEESE.get(), 2)
-            .requires(ModItems.SEA_SALT.get())
+            .requires(FORGE_SALTS)
             .requires(Items.MILK_BUCKET)
             .unlockedBy("has_milk", this.hasItem.apply(Items.MILK_BUCKET))
-            .unlockedBy("has_salt", this.hasItem.apply(ModItems.SEA_SALT.get()))
+            .unlockedBy("has_salt", this.hasItem.apply(FORGE_SALTS))
             .save(this.consumer);
 
         ShapelessRecipeBuilder.shapeless(RecipeCategory.FOOD, ModItems.DOUGH.get(), 2)


### PR DESCRIPTION
Imp #64 .
I can't validate this patch, `gradlew` complains about `java.lang.IllegalArgumentException: Expected authority at index 2: //` in `:fabric` and refuses to build the project.