### PR TITLE
🐛 Freezer variants lack translations

### DIFF
--- a/common/src/main/resources/assets/refurbished_furniture/lang/en_au.json
+++ b/common/src/main/resources/assets/refurbished_furniture/lang/en_au.json
@@ -191,6 +191,8 @@
     "block.refurbished_furniture.black_cooler": "Black Esky",
     "block.refurbished_furniture.light_fridge": "Light Fridge",
     "block.refurbished_furniture.dark_fridge": "Dark Fridge",
+    "item.refurbished_furniture.light_freezer": "Light Freezer",
+    "item.refurbished_furniture.dark_freezer": "Dark Freezer",
     "block.refurbished_furniture.light_toaster": "Light Toaster",
     "block.refurbished_furniture.dark_toaster": "Dark Toaster",
     "block.refurbished_furniture.light_microwave": "Light Microwave",

--- a/common/src/main/resources/assets/refurbished_furniture/lang/en_us.json
+++ b/common/src/main/resources/assets/refurbished_furniture/lang/en_us.json
@@ -191,6 +191,8 @@
     "block.refurbished_furniture.black_cooler": "Black Cooler",
     "block.refurbished_furniture.light_fridge": "Light Fridge",
     "block.refurbished_furniture.dark_fridge": "Dark Fridge",
+    "item.refurbished_furniture.light_freezer": "Light Freezer",
+    "item.refurbished_furniture.dark_freezer": "Dark Freezer",
     "block.refurbished_furniture.light_toaster": "Light Toaster",
     "block.refurbished_furniture.dark_toaster": "Dark Toaster",
     "block.refurbished_furniture.light_microwave": "Light Microwave",


### PR DESCRIPTION
Kia ora,

**The issue (unexpected behaviour)**
I've encountered a bug for awhile, and I've noticed that the freezer variants lack translations. While they are obviously part of the same item (the fridge), they collectively form two blocks (as I am sure you know). Unfortunately, if anyone is using common mods such as JEI to see what they are looking at, the upper bit (fridge) looks fine, and provides the correct string as has already been defined in the lang files. However, this does not apply for the freezer portion. After checking, there is no freezer string in the lang files, therefore users are met with solely the block's string.

**Expected behaviour**
As detailed, the expected behaviour would for this to operate the exact same as the fridge portion of the item, displaying the block's name, rather than its lang string. In this instance, this would be "[variant] Freezer", just like "[variant] Fridge" for the upper portion.

**Steps to reproduce**
1. Ensure you have JEI or a similar mod installed.
2. Place down any fridge variant.
3. Look at the upper (fridge) portion, and see the expected behaviour in the JEI tooltip.
4. Look at the bottom (freezer) portion, and observe the unexpected behaviour in the JEI tooltip.

**How this PR addresses the unexpected behaviour**
This PR addresses the unexpected behaviour by including the appropriate i18n strings in the lang files. As freezer is the same in en-US and en-AU, these have been given the same translations in each file.

**This is not an incompatibility issue**
To emphasise, this is not an incompatibility issue. JEI, as far as I am aware, only fetches the lang strings from other mods. As, in many instances, seeing block names, is possible through means such as JEI (which is extremely common!) it is crucial to ensure translations are included where appropriate, and unfortunately this was an oversight!

**A thanks**
I would like to express my appreciation for the work that the maintainers put into this mod (MrCrayfish), you do an excellent job and it is incredibly enjoyable to play with. It is a much-needed and appreciated enhancement to the game, and people, including myself, have loved your work for many many many years now.

**Supporting images**
Expected behaviour:
![image](https://github.com/user-attachments/assets/8ab1a81d-4a76-4b75-bde6-11cbbc6a5e70)

Unexpected behaviour:
![image](https://github.com/user-attachments/assets/da7456d9-cbc1-4775-aa7c-fdd353929734)

**TL;DR** lang files missing for freezer variants, means users of popular mods such as JEI only see the block string rather than its actual name. PR addresses this by included the appropriate translations.

Many thanks, Carolina.