### PR TITLE
🐛 Fix cutting board item placement

### DIFF
--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/block/CuttingBoardBlock.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/block/CuttingBoardBlock.java
@@ -76,20 +76,22 @@ public class CuttingBoardBlock extends FurnitureHorizontalEntityBlock implements
     {
         if(level.getBlockEntity(pos) instanceof CuttingBoardBlockEntity cuttingBoard)
         {
+            if(level.isClientSide())
+            {
+                return InteractionResult.SUCCESS;
+            }
+
             ItemStack heldItem = player.getItemInHand(hand);
             if(heldItem.is(ConventionalTags.Items.TOOLS_KNIVES))
             {
                 boolean dropAsEntity = !Services.ENTITY.isFakePlayer(player);
                 if(cuttingBoard.sliceItem(level, dropAsEntity))
                 {
-                    if(!level.isClientSide())
-                    {
-                        heldItem.hurtAndBreak(1, player, hand.asEquipmentSlot());
-                    }
+                    heldItem.hurtAndBreak(1, player, hand.asEquipmentSlot());
                 }
                 return InteractionResult.SUCCESS;
             }
-            else if(cuttingBoard.placeItem(heldItem)) // Modify to only be server side
+            else if(cuttingBoard.placeItem(heldItem, !player.getAbilities().instabuild))
             {
                 return InteractionResult.SUCCESS;
             }

--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/blockentity/CuttingBoardBlockEntity.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/blockentity/CuttingBoardBlockEntity.java
@@ -94,16 +94,20 @@ public class CuttingBoardBlockEntity extends BasicLootBlockEntity
      * cutting board recipe.
      *
      * @param heldItem the item to place on the cutting board
+     * @param consumeItem if the held item should be consumed after being placed
      * @return True if an item was placed
      */
-    public boolean placeItem(ItemStack heldItem)
+    public boolean placeItem(ItemStack heldItem, boolean consumeItem)
     {
         int placeIndex = this.getPlaceIndex();
         if(this.canPlaceItem(placeIndex, heldItem))
         {
             ItemStack copy = heldItem.copy();
             copy.setCount(1);
-            heldItem.shrink(1);
+            if(consumeItem)
+            {
+                heldItem.shrink(1);
+            }
             if(!this.level.isClientSide())
             {
                 this.placedByPlayer = true;


### PR DESCRIPTION
Fixes an issue where placing bread on a cutting board in survival could immediately eject the item instead of leaving it on the board.

The cutting board was attempting recipe-backed placement logic on the client side, while recipe lookup only succeeds on the server. This could cause client/server interaction flow to diverge. The fix makes the client acknowledge the interaction and keeps the actual placement mutation server-side.

Also preserves creative behavior by avoiding item consumption when the player has instabuild.

Tested:
- ./gradlew :fabric:runDatagen :neoforge:runData
- ./gradlew :common:compileJava
- ./gradlew :fabric:compileJava :neoforge:compileJava
- ./gradlew :fabric:build