### PR TITLE
✨ Add Farmer's Delight Refabricated compatibility

### DIFF
--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/ConventionalTags.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/ConventionalTags.java
@@ -12,7 +12,9 @@ public class ConventionalTags
 {
     public static class Items
     {
+        public static final TagKey<Item> TOOLS_KNIFE = tag("c", "tools/knife");
         public static final TagKey<Item> TOOLS_KNIVES = tag("c", "tools/knives");
+        public static final TagKey<Item> FARMERS_DELIGHT_TOOLS_KNIVES = tag("farmersdelight", "tools/knives");
 
         public static TagKey<Item> tag(String modId, String name)
         {

--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/core/ModTags.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/core/ModTags.java
@@ -34,6 +34,7 @@ public class ModTags
         public static final TagKey<Item> TOOLS_KNIVES = tag("tools/knives");
         public static final TagKey<Item> GRILLS = tag("grills");
         public static final TagKey<Item> COOLERS = tag("coolers");
+        public static final TagKey<Item> TOASTER_BREAD_SLICES = tag("toaster_bread_slices");
         public static final TagKey<Item> TRAMPOLINES = tag("trampolines");
         public static final TagKey<Item> SOFAS = tag("sofas");
         public static final TagKey<Item> STOOLS = tag("stools");

--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonItemTagsProvider.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonItemTagsProvider.java
@@ -7,6 +7,9 @@ import com.mrcrayfish.furniture.refurbished.core.ModTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.VanillaItemTagsProvider;
+import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 
 import java.util.concurrent.CompletableFuture;
@@ -1084,7 +1087,17 @@ public class CommonItemTagsProvider extends VanillaItemTagsProvider
             .add(Items.HONEYCOMB_BLOCK);
 
         this.tag(ConventionalTags.Items.TOOLS_KNIVES)
-            .addTag(ModTags.Items.TOOLS_KNIVES);
+            .addTag(ModTags.Items.TOOLS_KNIVES)
+            .addOptionalTag(ConventionalTags.Items.TOOLS_KNIFE)
+            .addOptionalTag(ConventionalTags.Items.FARMERS_DELIGHT_TOOLS_KNIVES);
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "flint_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "iron_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "golden_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "diamond_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "netherite_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "farmersdelight", "copper_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "moredelight", "wooden_knife");
+        this.addOptionalItem(ConventionalTags.Items.TOOLS_KNIVES, "moredelight", "stone_knife");
 
         // Common tags
         this.tag(ModTags.Items.COMMON_ENCHANTABLES)
@@ -1098,10 +1111,20 @@ public class CommonItemTagsProvider extends VanillaItemTagsProvider
             .add(ModItems.BREAD_SLICE.get())
             .add(ModItems.TOAST.get());
 
+        this.tag(ModTags.Items.TOASTER_BREAD_SLICES)
+            .add(ModItems.BREAD_SLICE.get());
+        this.addOptionalItem(ModTags.Items.TOASTER_BREAD_SLICES, "farmersdelight", "bread_slice");
+        this.addOptionalItem(ModTags.Items.TOASTER_BREAD_SLICES, "moredelight", "bread_slice");
+
         this.tag(ModTags.Items.COMMON_TOOLS_KNIVES)
             .addTag(ModTags.Items.TOOLS_KNIVES);
 
         this.tag(ModTags.Items.COMMON_TOOLS_WRENCH)
             .add(ModItems.WRENCH.get());
+    }
+
+    private void addOptionalItem(TagKey<Item> tag, String namespace, String path)
+    {
+        this.getOrCreateRawBuilder(tag).addOptionalElement(Identifier.fromNamespaceAndPath(namespace, path));
     }
 }

--- a/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonRecipeProvider.java
+++ b/common/src/main/java/com/mrcrayfish/furniture/refurbished/data/CommonRecipeProvider.java
@@ -595,7 +595,7 @@ public class CommonRecipeProvider extends RecipeProvider
         this.freezerSolidifying(ProcessingRecipe.Category.BLOCKS, Items.PACKED_ICE, Items.BLUE_ICE, 2400, 1.0F);
 
         // Toasting
-        this.toasterHeating(ProcessingRecipe.Category.FOOD, ModItems.BREAD_SLICE.get(), ModItems.TOAST.get(), 300, 0.5F);
+        this.toasterHeating(ProcessingRecipe.Category.FOOD, Ingredient.of(this.items.getOrThrow(ModTags.Items.TOASTER_BREAD_SLICES)), ModItems.TOAST.get(), 300, 0.5F);
         this.toasterHeating(ProcessingRecipe.Category.FOOD, ModItems.CHEESE_SANDWICH.get(), ModItems.CHEESE_TOASTIE.get(), 400, 0.5F);
 
         // Slicing
@@ -1098,6 +1098,11 @@ public class CommonRecipeProvider extends RecipeProvider
     private void toasterHeating(ProcessingRecipe.Category category, ItemLike baseItem, ItemLike heatedItem, int heatingTime, float experience)
     {
         this.processing(ToasterHeatingRecipe::new, "toasting", category, Ingredient.of(baseItem), heatedItem, 1, heatingTime);
+    }
+
+    private void toasterHeating(ProcessingRecipe.Category category, Ingredient ingredient, ItemLike heatedItem, int heatingTime, float experience)
+    {
+        this.processing(ToasterHeatingRecipe::new, "toasting", category, ingredient, heatedItem, 1, heatingTime);
     }
 
     private void microwaveHeating(ProcessingRecipe.Category category, ItemLike baseItem, ItemLike heatedItem, int heatingTime, float experience)


### PR DESCRIPTION
## Summary
- accept Farmer's Delight Refabricated knives on the cutting board via common/compat knife tags and optional item ids
- add More Delight wooden/stone knives as optional cutting board knives
- allow toaster recipes to accept tagged bread slices, including optional Farmer's Delight and More Delight bread slices

## Testing
- ./gradlew :common:compileJava
- ./gradlew :fabric:runDatagen :neoforge:runData
- ./gradlew :fabric:build :neoforge:build