### PR TITLE
Fix NeoForge fluid transaction lifecycle

### DIFF
--- a/neoforge/src/main/java/com/mrcrayfish/furniture/refurbished/platform/NeoForgeFluidHelper.java
+++ b/neoforge/src/main/java/com/mrcrayfish/furniture/refurbished/platform/NeoForgeFluidHelper.java
@@ -22,7 +22,6 @@ import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.fluid.FluidStacksResourceHandler;
 import net.neoforged.neoforge.transfer.fluid.FluidUtil;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
-import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 
@@ -59,8 +58,15 @@ public class NeoForgeFluidHelper implements IFluidHelper
     @Override
     public InteractionResult performInteractionWithBlock(Player player, InteractionHand hand, Level level, BlockPos pos, Direction face)
     {
-        // TODO 26.2 test
-        return FluidUtil.interactWithFluidHandler(player, hand, level, pos, face, Transaction.openRoot()) ? InteractionResult.SUCCESS : InteractionResult.PASS;
+        try(Transaction tx = Transaction.openRoot())
+        {
+            if(FluidUtil.interactWithFluidHandler(player, hand, level, pos, face, tx))
+            {
+                tx.commit();
+                return InteractionResult.SUCCESS;
+            }
+        }
+        return InteractionResult.PASS;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Manage the root NeoForge fluid transaction with try-with-resources and commit it only when the fluid interaction succeeds. This also removes the unused transaction-context import.

## Root cause

The 26.2 port passed a newly opened root transaction directly into `FluidUtil` and discarded the handle. When an interaction returned `PASS`, that root remained active. Sink and other fluid-container fallback operations then attempted to open another root transaction, causing the client crash.

Fixes #203.

## Validation

- `TARGET_LOADER=neoforge ./gradlew :neoforge:build`
- `git diff --check`
- verified in multiplayer with matching patched client and server jars: right-clicking the sink no longer crashes the client
